### PR TITLE
token no longer returned on signup, tests changed to allow for this

### DIFF
--- a/resources/auth/controller.js
+++ b/resources/auth/controller.js
@@ -24,8 +24,6 @@ exports.signup = async (req, res) => {
       isConfirmed: false,
     });
 
-    const token = generateToken(userCreated);
-
     const emailToken = generateToken(userCreated, EMAIL_SECRET);
 
     sendEmail(welcomeText, email, emailTemplate(fullName, emailToken), null);
@@ -33,7 +31,6 @@ exports.signup = async (req, res) => {
     res.status(201).json({
       message: `User created successfully`,
       data: {
-        token,
         user: userCreated,
       },
     });

--- a/resources/auth/router.spec.js
+++ b/resources/auth/router.spec.js
@@ -29,6 +29,11 @@ const userObject = {
   isConfirmed: false,
 };
 
+const userObject2 = {
+  email: 'maaruf@email.com',
+  password: 'maaruf',
+};
+
 const exampleMail = {
   to: 'john@domain.com',
   from: 'jimmy@domain.com',
@@ -64,14 +69,14 @@ describe('Auth Router', () => {
       done();
     });
 
-    test('Token is returned on signup successful', async done => {
+    test('Token is not returned on signup successful', async done => {
       const res = await request(server)
         .post('/api/auth/register')
         .send(userObject);
 
       expect(res.status).toBe(201);
 
-      expect(res.body.data.token).not.toBe(null || undefined);
+      expect(res.body.data.token).toBe(null || undefined);
       done();
     });
 
@@ -430,12 +435,16 @@ describe('Auth Router', () => {
 
   describe('Update password endpoint', () => {
     test('Returns 200 on successful update', async done => {
-      const res = await request(server)
+      await request(server)
         .post('/api/auth/register')
         .send(userObject);
 
+      const res = await request(server)
+        .post('/api/auth/login')
+        .send(loginUserObject);
+
       const { token } = res.body.data;
-      expect(res.status).toBe(201);
+      expect(res.status).toBe(200);
       expect(token).not.toBe(null || undefined);
 
       const response = await request(server)
@@ -453,12 +462,16 @@ describe('Auth Router', () => {
     });
 
     test('Fails if old password is invalid', async done => {
-      const res = await request(server)
+      await request(server)
         .post('/api/auth/register')
         .send(userObject);
 
+      const res = await request(server)
+        .post('/api/auth/login')
+        .send(loginUserObject);
+
       const { token } = res.body.data;
-      expect(res.status).toBe(201);
+      expect(res.status).toBe(200);
       expect(token).not.toBe(null || undefined);
 
       const response = await request(server)

--- a/resources/decks/router.spec.js
+++ b/resources/decks/router.spec.js
@@ -9,11 +9,21 @@ const userObject = {
   imageUrl: 'google.com',
 };
 
+const loginUserObject = {
+  email: 'testuser@xyz.com',
+  password: 'ALongSecurePassword',
+};
+
 const userObject2 = {
   fullName: 'Test User3',
   email: 'testusesr@xyz.com',
   password: 'ALongSecurePassword',
   imageUrl: 'google.com',
+};
+
+const loginUserObject2 = {
+  email: 'testuser@xyz.com',
+  password: 'ALongSecurePassword',
 };
 
 let user;
@@ -27,16 +37,24 @@ beforeEach(async done => {
   await db.seed.run({
     specific: '03-tags-data.js',
   });
-  const userRes = await request(server)
+  await request(server)
     .post('/api/auth/register')
     .send(userObject);
+
+  const userRes = await request(server)
+    .post('/api/auth/login')
+    .send(loginUserObject);
 
   authToken = userRes.body.data.token;
   user = userRes.body.data.user;
 
-  const userRes2 = await request(server)
+  await request(server)
     .post('/api/auth/register')
     .send(userObject2);
+
+  const userRes2 = await request(server)
+    .post('/api/auth/login')
+    .send(loginUserObject2);
 
   authToken2 = userRes2.body.data.user;
   done();

--- a/resources/flashcards/router.spec.js
+++ b/resources/flashcards/router.spec.js
@@ -9,6 +9,11 @@ const userObject = {
   imageUrl: 'google.com',
 };
 
+const loginUserObject = {
+  email: 'testuser@xyz.com',
+  password: 'ALongSecurePassword',
+};
+
 let authToken;
 // eslint-disable-next-line no-unused-vars
 let user;
@@ -23,9 +28,13 @@ beforeEach(async done => {
   await db.seed.run({
     specific: '03-tags-data.js',
   });
-  const userRes = await request(server)
+  await request(server)
     .post('/api/auth/register')
     .send(userObject);
+
+  const userRes = await request(server)
+    .post('/api/auth/login')
+    .send(loginUserObject);
 
   const deckRes = await request(server)
     .post('/api/decks')

--- a/resources/users/router.spec.js
+++ b/resources/users/router.spec.js
@@ -10,14 +10,24 @@ const userObject = {
   isConfirmed: false,
 };
 
+const loginUserObject = {
+  email: 'h.kakashi@gmail.com',
+  password: 'aVeryLongPassword',
+};
+
 let user;
 let authToken;
 
 beforeEach(async done => {
   await db.raw('TRUNCATE TABLE users CASCADE');
-  const userRes = await request(server)
+
+  await request(server)
     .post('/api/auth/register')
     .send(userObject);
+
+  const userRes = await request(server)
+    .post('/api/auth/login')
+    .send(loginUserObject);
 
   authToken = userRes.body.data.token;
   user = userRes.body.data.user;


### PR DESCRIPTION
# Description

Token no longer returned on signup, tests have been changed so that they still pass without register token.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works .
- [ ] New and existing unit tests pass locally with my changes

##Trello Card
https://trello.com/c/EfIsHPKy/62-signup-sets-token-to-localstorage-makes-email-verification-redundant
