### PR TITLE
Fix issue with new deck response

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "npx knex migrate:rollback --env=testing && npx knex migrate:latest --env=testing",
-    "test": "cross-env NODE_ENV=testing jest --detectOpenHandles --forceExit --coverage --runInBand",
+    "test": "cross-env NODE_ENV=testing jest --detectOpenHandles --forceExit --coverage --runInBand --watchAll=true",
     "start": "node index.js",
     "server": "nodemon index.js ",
     "lint": "eslint . --ext .js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "npx knex migrate:rollback --env=testing && npx knex migrate:latest --env=testing",
-    "test": "cross-env NODE_ENV=testing jest --detectOpenHandles --forceExit --coverage --runInBand --watchAll=true",
+    "test": "cross-env NODE_ENV=testing jest --detectOpenHandles --forceExit --coverage --runInBand",
     "start": "node index.js",
     "server": "nodemon index.js ",
     "lint": "eslint . --ext .js",

--- a/resources/decks/controller.js
+++ b/resources/decks/controller.js
@@ -55,11 +55,7 @@ exports.addDeck = async (req, res) => {
     }
     const accessCxnData = { user_id: subject, deck_id: deck.id };
     await Decks.createAccessConnection(accessCxnData);
-    const newDeckRes = {
-      deck: { ...deck, deck_id: deck.id, deck_name: deck.name, flashcards: [] },
-    };
-    delete newDeckRes.deck.id;
-    delete newDeckRes.deck.name;
+    const newDeckRes = await Decks.findById(deck.id);
     res.status(201).json(newDeckRes);
   } catch (error) {
     res.status(500).json({ message: `Error adding deck: ${error}` });

--- a/resources/decks/controller.js
+++ b/resources/decks/controller.js
@@ -56,7 +56,7 @@ exports.addDeck = async (req, res) => {
     const accessCxnData = { user_id: subject, deck_id: deck.id };
     await Decks.createAccessConnection(accessCxnData);
     const newDeckRes = await Decks.findById(deck.id);
-    res.status(201).json(newDeckRes);
+    res.status(201).json({ deck: newDeckRes });
   } catch (error) {
     res.status(500).json({ message: `Error adding deck: ${error}` });
   }

--- a/resources/decks/router.spec.js
+++ b/resources/decks/router.spec.js
@@ -97,7 +97,7 @@ describe('Decks API endpoints', () => {
         .send({ name: 'Test-deck', tags: [1, 2, 3] });
 
       const response = await request(server)
-        .get(`/api/decks/${body.deck.id}`)
+        .get(`/api/decks/${body.deck.deck_id}`)
         .set('Authorization', authToken);
 
       expect(response.body.deck.deck_name).toEqual('Test-deck');
@@ -136,7 +136,7 @@ describe('Decks API endpoints', () => {
         .send({ name: 'new-deck', tags: [1, 2, 3] });
       expect(response.status).toBe(201);
       expect(response.body.deck.user_id).toBe(user.id);
-      expect(response.body.deck.name).toBe('new-deck');
+      expect(response.body.deck.deck_name).toBe('new-deck');
       done();
     });
   });
@@ -162,7 +162,7 @@ describe('Decks API endpoints', () => {
         .send({ name: 'Test-deck', tags: [1, 2, 3] });
 
       const response = await request(server)
-        .put(`/api/decks/${body.deck.id}`)
+        .put(`/api/decks/${body.deck.deck_id}`)
         .set('Authorization', authToken);
 
       expect(response.status).toBe(200);
@@ -176,7 +176,7 @@ describe('Decks API endpoints', () => {
         .send({ name: 'Test-deck', tags: [1, 2, 3] });
 
       const response = await request(server)
-        .put(`/api/decks/${body.deck.id}`)
+        .put(`/api/decks/${body.deck.deck_id}`)
         .set('Authorization', authToken)
         .send({ name: 'updated-deck' });
 
@@ -199,7 +199,7 @@ describe('Decks API endpoints', () => {
         .set('Authorization', authToken)
         .send({ name: 'Test-deck', tags: [1, 2, 3] });
       const response = await request(server)
-        .put(`/api/decks/${body.deck.id}`)
+        .put(`/api/decks/${body.deck.deck_id}`)
         .set('Authorization', authToken)
         .send({ addTags: [1000, 2131], removeTags: [230] });
       expect(response.status).toBe(400);
@@ -211,7 +211,7 @@ describe('Decks API endpoints', () => {
         .set('Authorization', authToken)
         .send({ name: 'Test-deck', tags: [1, 2, 3] });
       const response = await request(server)
-        .put(`/api/decks/${body.deck.id}`)
+        .put(`/api/decks/${body.deck.deck_id}`)
         .set('Authorization', authToken)
         .send({ addTags: [1, 2, 3] });
       expect(response.status).toBe(400);
@@ -223,7 +223,7 @@ describe('Decks API endpoints', () => {
         .set('Authorization', authToken)
         .send({ name: 'Test-deck', tags: [1, 2, 3] });
       const response = await request(server)
-        .put(`/api/decks/${body.deck.id}`)
+        .put(`/api/decks/${body.deck.deck_id}`)
         .set('Authorization', authToken2)
         .send({ addTags: [4, 5] });
       expect(response.status).toBe(401);
@@ -238,7 +238,7 @@ describe('Decks API endpoints', () => {
         .set('Authorization', authToken)
         .send({ name: 'Test-deck', tags: [1, 2, 3] });
       const response = await request(server).delete(
-        `/api/decks/${body.deck.id}`
+        `/api/decks/${body.deck.deck_id}`
       );
       expect(response.status).toBe(401);
       done();
@@ -251,14 +251,14 @@ describe('Decks API endpoints', () => {
         .send({ name: 'Test-deck', tags: [1, 2, 3] });
 
       const response = await request(server)
-        .delete(`/api/decks/${body.deck.id}`)
+        .delete(`/api/decks/${body.deck.deck_id}`)
         .set('Authorization', authToken);
 
       expect(response.status).toBe(204);
 
       // Check deck is deleted - should give Not Found response
       const responseDeleted = await request(server)
-        .get(`/api/decks/${body.deck.id}`)
+        .get(`/api/decks/${body.deck.deck_id}`)
         .set('Authorization', authToken);
 
       expect(responseDeleted.status).toEqual(404);
@@ -273,7 +273,7 @@ describe('Decks API endpoints', () => {
         .set('Authorization', authToken)
         .send({ name: 'Test-deck', tags: [1, 2, 3] });
       const response = await request(server)
-        .put(`/api/decks/access/${body.deck.id}`)
+        .put(`/api/decks/access/${body.deck.deck_id}`)
         .set('Authorization', authToken);
       expect(response.status).toBe(200);
       done();
@@ -284,7 +284,7 @@ describe('Decks API endpoints', () => {
         .set('Authorization', authToken)
         .send({ name: 'Test-deck', tags: [1, 2, 3] });
       const response = await request(server).put(
-        `/api/decks/access/${body.deck.id}`
+        `/api/decks/access/${body.deck.deck_id}`
       );
       expect(response.status).toBe(401);
       done();
@@ -298,11 +298,11 @@ describe('Decks API endpoints', () => {
         .set('Authorization', authToken)
         .send({ name: 'Test-deck', tags: [1, 2, 3] });
       await request(server)
-        .put(`/api/decks/access/${body.deck.id}`)
+        .put(`/api/decks/access/${body.deck.deck_id}`)
         .set('Authorization', authToken);
 
       const response = await request(server)
-        .delete(`/api/decks/access/${body.deck.id}`)
+        .delete(`/api/decks/access/${body.deck.deck_id}`)
         .set('Authorization', authToken);
       expect(response.status).toBe(204);
       done();
@@ -312,7 +312,7 @@ describe('Decks API endpoints', () => {
         .post('/api/decks/')
         .set('Authorization', authToken)
         .send({ name: 'Test-deck', tags: [1, 2, 3] });
-      await request(server).put(`/api/decks/access/${body.deck.id}`);
+      await request(server).put(`/api/decks/access/${body.deck.deck_id}`);
 
       const response = await request(server).delete(`/api/decks/access/500`);
       expect(response.status).toBe(401);
@@ -327,7 +327,7 @@ describe('Decks API endpoints', () => {
         .set('Authorization', authToken)
         .send({ name: 'Test-deck', tags: [1, 2, 3] });
       await request(server)
-        .put(`/api/decks/access/${body.deck.id}`)
+        .put(`/api/decks/access/${body.deck.deck_id}`)
         .set('Authorization', authToken);
       const response = await request(server)
         .get(`/api/decks/access/`)
@@ -341,7 +341,7 @@ describe('Decks API endpoints', () => {
         .set('Authorization', authToken)
         .send({ name: 'Test-deck', tags: [1, 2, 3] });
       await request(server)
-        .put(`/api/decks/access/${body.deck.id}`)
+        .put(`/api/decks/access/${body.deck.deck_id}`)
         .set('Authorization', authToken);
       const response = await request(server).get(`/api/decks/access/`);
       expect(response.status).toBe(401);

--- a/resources/flashcards/router.spec.js
+++ b/resources/flashcards/router.spec.js
@@ -42,7 +42,7 @@ beforeEach(async done => {
     .set('Authorization', userRes.body.data.token);
 
   authToken = userRes.body.data.token;
-  flashcard.deckId = deckRes.body.deck.id;
+  flashcard.deckId = deckRes.body.deck.deck_id;
 
   user = userRes.body.data.user;
   done();


### PR DESCRIPTION
# Description

A newly created deck response now includes the deck's tags. This fixes an issue on the frontend where when a newly created deck's tags' array was accessed it would cause a crash as there was no tags property. Tests have also been updated to pass with these changes.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works .
- [ ] New and existing unit tests pass locally with my changes
